### PR TITLE
add Efficient Channel Attention

### DIFF
--- a/pytorch_tools/models/efficientnet.py
+++ b/pytorch_tools/models/efficientnet.py
@@ -234,7 +234,7 @@ def _decode_block_string(block_string):
         out_channels=int(options["o"]),
         dw_kernel_size=int(options["k"]),
         stride=tuple([options["s"], options["s"]]),
-        use_se=float(options["se"]) > 0 if "se" in options else False,
+        attn_type="se" if "se" in options else None,
         expand_ratio=int(options["e"]),
         noskip="noskip" in block_string,
         num_repeat=int(options["r"]),

--- a/pytorch_tools/models/tresnet.py
+++ b/pytorch_tools/models/tresnet.py
@@ -83,10 +83,7 @@ class TResNet(ResNet):
         self.num_blocks = sum(layers)
         self.drop_connect_rate = drop_connect_rate
 
-        # in the paper they use conv1x1 but in code conv3x3 (which seems better)
-        self.conv1 = nn.Sequential(SpaceToDepth(), conv3x3(in_channels * 16, stem_width))
-        self.bn1 = norm_layer(stem_width, activation=norm_act)
-        self.maxpool = nn.Identity() # not used but needed for code compatability
+        self._make_stem("space2depth", stem_width, in_channels, norm_layer, norm_act)
 
         if output_stride not in [8, 16, 32]:
             raise ValueError("Output stride should be in [8, 16, 32]")

--- a/pytorch_tools/models/tresnet.py
+++ b/pytorch_tools/models/tresnet.py
@@ -98,7 +98,7 @@ class TResNet(ResNet):
         # elif output_stride == 32:
         stride_3, stride_4, dilation_3, dilation_4 = 2, 2, 1, 1
 
-        largs = dict(use_se=True, norm_layer=norm_layer, norm_act=norm_act, antialias=True)
+        largs = dict(attn_type="se", norm_layer=norm_layer, norm_act=norm_act, antialias=True)
         self.block = TBasicBlock
         self.expansion = TBasicBlock.expansion
         self.layer1 = self._make_layer(stem_width, layers[0], stride=1, **largs)
@@ -107,7 +107,7 @@ class TResNet(ResNet):
         self.block = TBottleneck # first 2 - Basic, last 2 - Bottleneck
         self.expansion = TBottleneck.expansion
         self.layer3 = self._make_layer(stem_width * 4, layers[2], stride=stride_3, dilation=dilation_3, **largs)
-        largs.update(use_se=False) # no se in last layer
+        largs.update(attn_type=None) # no se in last layer
         self.layer4 = self._make_layer(stem_width * 8, layers[3], stride=stride_4, dilation=dilation_4, **largs)
         self.global_pool = FastGlobalAvgPool2d(flatten=True)
         self.num_features = stem_width * 8 * self.expansion

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -101,3 +101,8 @@ def test_num_parameters(name_num_params):
     name, num_params = name_num_params[0]
     m = models.__dict__[name]()
     assert pt.utils.misc.count_parameters(m)[0] == num_params
+
+@pytest.mark.parametrize('stem_type', ["", "deep", "space2depth"])
+def test_resnet_stem_type(stem_type):
+    m = models.resnet50(stem_type=stem_type)
+    _test_forward(m)


### PR DESCRIPTION
Добавил Efficient Channel Attention из [этой статьи](https://arxiv.org/abs/1910.03151)
Код близок к исходному, но сильно упрощен

Для того чтобы добавить этот модуль пришлось поменять параметр `use_se` (use squeeze excitation) на более общий `attn_type` (attention type). Это точно еще пригодится в будущем. Тесты проходит.
Краткое описание того, почему это должно работать
![image](https://user-images.githubusercontent.com/14337581/82080130-aef59600-96ec-11ea-8a34-57829407489b.png)


