### PR TITLE
change `deep_stem` to `stem_type`

### DIFF
--- a/pytorch_tools/models/tresnet.py
+++ b/pytorch_tools/models/tresnet.py
@@ -83,10 +83,7 @@ class TResNet(ResNet):
         self.num_blocks = sum(layers)
         self.drop_connect_rate = drop_connect_rate
 
-        # in the paper they use conv1x1 but in code conv3x3 (which seems better)
-        self.conv1 = nn.Sequential(SpaceToDepth(), conv3x3(in_channels * 16, stem_width))
-        self.bn1 = norm_layer(stem_width, activation=norm_act)
-        self.maxpool = nn.Identity() # not used but needed for code compatability
+        self._make_stem("space2depth", stem_width, in_channels, norm_layer, norm_act)
 
         if output_stride not in [8, 16, 32]:
             raise ValueError("Output stride should be in [8, 16, 32]")

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -101,3 +101,8 @@ def test_num_parameters(name_num_params):
     name, num_params = name_num_params[0]
     m = models.__dict__[name]()
     assert pt.utils.misc.count_parameters(m)[0] == num_params
+
+@pytest.mark.parametrize('stem_type', ["", "deep", "space2depth"])
+def test_resnet_stem_type(stem_type):
+    m = models.resnet50(stem_type=stem_type)
+    _test_forward(m)


### PR DESCRIPTION
Раньше можно было выбирать между дефолтным ResNet stem и его глубокой версией (которая пришла из статьи про Bag of Tricks и известна как ResNetD). Сейчас добавил еще один вариант stem из статьи про TResNet. Этот вариант быстрее, требует меньше памяти и как утверждается лучше чем deep (но это надо еще проверить)

Вот сравнение по скорости:
```
Resnet50 25.56M params
Mean of 10 runs 10 iters each BS=64:
         28.11+-0.14 msecs Forward. 104.41+-5.17 msecs Backward. Max memory: 3065.72Mb. 482.98 imgs/sec
Resnet50 deep 25.58M params
Mean of 10 runs 10 iters each BS=64:
         29.92+-0.07 msecs Forward. 112.15+-4.93 msecs Backward. Max memory: 3261.11Mb. 450.50 imgs/sec
Resnet50 space2depth 25.58M params
Mean of 10 runs 10 iters each BS=64:
         26.27+-0.16 msecs Forward. 97.06+-3.60 msecs Backward. Max memory: 2813.96Mb. 518.91 imgs/sec
```