### PR TITLE
move state reduce inside wrapper

### DIFF
--- a/pytorch_tools/fit_wrapper/callbacks.py
+++ b/pytorch_tools/fit_wrapper/callbacks.py
@@ -231,24 +231,6 @@ class PhasesScheduler(Callback):
             param_group["momentum"] = mom
 
 
-class StateReduce(Callback):
-    """
-    Reduced everything in state (that needs reduction) at the end of loader.
-    Needed for proper saving/logging/metric calculation
-    NOTE: Should be the first callback in the list to work as expected properly
-    """
-
-    def on_epoch_end(self):
-        if self.state.world_size == 1:
-            return
-        meters = self.state.train_metrics + [self.state.train_loss]
-        meters = meters + self.state.metric_meters + [self.state.loss_meter]
-        if self.state.val_loss is not None:
-            meters = meters + self.state.val_metrics + [self.state.val_loss]
-        for meter in meters:
-            meter = utils.reduce_meter(meter)
-
-
 class ReduceMode(Enum):
     MIN = "min"
     MAX = "max"

--- a/pytorch_tools/fit_wrapper/state.py
+++ b/pytorch_tools/fit_wrapper/state.py
@@ -55,3 +55,12 @@ class RunnerState:
     @property
     def epoch_log(self):
         return self.epoch + 1
+
+    def reduce_meters(self):
+        """aggregate loss and metrics from all processes"""
+        meters = self.train_metrics + [self.train_loss]
+        meters = meters + self.metric_meters + [self.loss_meter]
+        if self.val_loss is not None:
+            meters = meters + self.val_metrics + [self.val_loss]
+        for meter in meters:
+            meter = utils.reduce_meter(meter)  # NoOp if world_size == 1

--- a/pytorch_tools/fit_wrapper/wrapper.py
+++ b/pytorch_tools/fit_wrapper/wrapper.py
@@ -71,6 +71,7 @@ class Runner:
                 self.evaluate(val_loader, steps=val_steps)
                 self.state.val_loss = copy(self.state.loss_meter)
                 self.state.val_metrics = [copy(m) for m in self.state.metric_meters]
+            self.state.reduce_meters()
             self.callbacks.on_epoch_end()
         self.callbacks.on_end()
 


### PR DESCRIPTION
Убрал головную боль по усреднение в DDP случае, спрятав всю логику внутрь самого wrapper. Плюс посколько оно находится до `on_epoch_end`, все последующие колбеки будут видеть уже усредненные метрики. Пока больше не вижу для чего ещё нужен будет строгий порядок колбеков, плюс если они как-то внутри будут дополнительно сортироваться, это будет мешать. поэтому закрою #80 

closes #80 