### PR TITLE
fix loading effdet with coco weights

### DIFF
--- a/pytorch_tools/detection_models/efficientdet.py
+++ b/pytorch_tools/detection_models/efficientdet.py
@@ -328,7 +328,8 @@ def _efficientdet(arch, pretrained=None, **kwargs):
             )
             state_dict["cls_head_conv.1.weight"] = model.state_dict()[f"cls_head_conv.1.weight"]
             state_dict["cls_head_conv.1.bias"] = model.state_dict()["cls_head_conv.1.bias"]
-        model.load_state_dict(state_dict, strict=True)
+        # strict=False to avoid error on extra bias in BiFPN
+        model.load_state_dict(state_dict, strict=False) 
     setattr(model, "pretrained_settings", cfg_settings)
     return model
 


### PR DESCRIPTION
Closes #101 
Проблема была bias в BiFPN head, который по сути не нужен, но есть в весах. мне слишком лень удалять его из весов и заново их заливать, поэтому просто загружаю с `strict=False`, надеюсь это не вызовет проблем в будущем