### PR TITLE
refactor tiler to support 3d case

### DIFF
--- a/pytorch_tools/utils/tiles.py
+++ b/pytorch_tools/utils/tiles.py
@@ -1,0 +1,186 @@
+"""
+Implementation of tile-based inference allowing to predict huge images that does not fit into GPU memory entirely
+in a sliding-window fashion and merging prediction mask back to full-resolution.
+
+Hacked together by @zakajd & @bonlime
+
+Reference:
+    https://github.com/BloodAxe/pytorch-toolbelt/blob/develop/pytorch_toolbelt/inference/tiles.py
+    https://github.com/xinntao/Real-ESRGAN/blob/master/realesrgan/utils.py
+    https://github.com/victorca25/iNNfer
+"""
+import itertools
+from typing import Callable, Optional, List
+
+import torch
+from torch.nn import functional as F
+
+
+def compute_pyramid_patch_weight_loss(width: int, height: int, depth: Optional[int] = None) -> torch.Tensor:
+    """Compute a weight matrix that assigns bigger weight on pixels in center and
+    less weight to pixels on image boundary. This weight matrix then used for merging
+    individual tile predictions and helps dealing with prediction artifacts on tile boundaries.
+
+    Args:
+        width: Tile width
+        height: Tile height
+        depth: Tile depth (used in 3d case).
+
+    Returns:
+        Weight matrix of shape (1, width, height, [depth])
+
+    """
+    Dcx = torch.linspace(-width * 0.5 + 0.5, width * 0.5 - 0.5, width).square()
+    Dcy = torch.linspace(-height * 0.5 + 0.5, height * 0.5 - 0.5, height).square()
+    Dcz = 0
+    if depth is not None:
+        Dcz = torch.linspace(-depth * 0.5 + 0.5, depth * 0.5 - 0.5, depth).square()
+        Dcz = Dcz[None, None, :]
+
+    # eucl distance to center
+    Dc = (Dcx[:, None, None] + Dcy[None, :, None] + Dcz).sqrt()
+
+    De_x = torch.linspace(0.5, width - 0.5, width).abs()
+    De_x = torch.minimum(De_x, De_x.flip(dims=(0,)))
+
+    De_y = torch.linspace(0.5, height - 0.5, height).abs()
+    De_y = torch.minimum(De_y, De_y.flip(dims=(0,)))
+
+    De_z = torch.tensor(torch.inf)
+    if depth is not None:
+        De_z = torch.linspace(0.5, depth - 0.5, depth).abs()
+        De_z = torch.minimum(De_z, De_z.flip(dims=(0,)))
+        De_z = De_z[None, None, :]
+
+    # distance to the closest border
+    De = torch.minimum(De_x[:, None, None], De_y[None, :, None])
+    De = torch.minimum(De, De_z)
+
+    W = De / (Dc + De)
+    # normalize weights
+    depth_dim = 1 if depth is None else depth
+    W = W / W.sum() * (width * height * depth_dim)
+
+    # remove extra axis if not needed
+    W = W[..., 0] if depth is None else W
+    return W.unsqueeze(dim=0)
+
+
+class TileInference:
+    """Wrapper for models that implements tile-based inference allowing to predict huge images
+    that does not fit into GPU memory entirely in a sliding-window fashion.
+
+    Args:
+        tile_size: int
+        overlap: By how many pixels tiles are overlapped with each other
+        model: Any callable used for processing single input patch.
+        scale: ratio of output size to input size
+        fusion: One of {'mean', 'pyramid'}. Defines how overlapped patches are weighted.
+    """
+
+    def __init__(
+        self,
+        tile_size: List[int],
+        overlap: List[int],
+        model: Callable,
+        scale: float = 1,
+        fusion: str = "mean",
+    ):
+        # Check input values
+        if isinstance(tile_size, int):
+            raise ValueError("TileInference expects `tile_size` as `List[int]` not `int` ")
+
+        self.tile_size = torch.tensor(tile_size)
+        self.overlap = torch.tensor(overlap)
+        if not all(self.tile_size > 2 * self.overlap):
+            raise ValueError("Overlap can't be larger than tile size")
+
+        self.tile_step = self.tile_size - 2 * self.overlap
+
+        self.scale = scale
+        self.model = model
+        weights = {"mean": self._mean, "pyramid": self._pyramid}
+        self.weight = weights[fusion]((self.tile_size * scale).long())
+
+    def _mean(self, tile_size: List[int]):
+        return torch.ones((1, *tile_size))
+
+    def _pyramid(self, tile_size: List[int]):
+        return compute_pyramid_patch_weight_loss(*tile_size)
+
+    @torch.no_grad()
+    def __call__(self, image: torch.Tensor):
+        """It will first crop input images to tiles, and then process each tile.
+        Finally, all the processed tiles are merged into one images.
+
+        Args:
+            image: ND tensor with shape (C, H, W, [D])
+
+        """
+
+        # Number of tiles in all directions.
+        shapes_tensor = torch.tensor(image.shape[1:], dtype=torch.long)
+        n_tiles = shapes_tensor.div(self.tile_step).ceil().long()
+
+        extra_pads = n_tiles * self.tile_step + 2 * self.overlap - shapes_tensor
+        pad_l, pad_r = extra_pads.div(2, rounding_mode="floor"), extra_pads - extra_pads.div(2, rounding_mode="floor")
+        pads = torch.stack([pad_r, pad_l], dim=1).flatten().flip(dims=(0,))
+
+        # Make image divisible by `tile_size` and add border pixels if necessary
+        # Other border types produce artifacts
+        padded_image = F.pad(image, pads.tolist(), mode="replicate")
+        tile_generator = self.iter_split(padded_image)
+
+        # Empty output tensor
+        out_shape = (torch.tensor(padded_image.shape[1:]) * self.scale).long()
+        out_shape = [image.size(0), *out_shape.tolist()]
+        output = torch.zeros(out_shape)
+        # Used to save weight mask used for blending
+        norm_mask = torch.zeros(out_shape)
+
+        # Move weights to correct device and dtype
+        w = self.weight.to("cpu")
+
+        for tile, out_slice in tile_generator:
+            # Process
+            output_tile = self.model(tile).cpu()
+
+            channel_slice = slice(0, output_tile.size(0))
+            output[[channel_slice, *out_slice]] += output_tile * w
+            norm_mask[[channel_slice, *out_slice]] += w
+
+        # Normalize by mask to weighten overlapped patches.
+        output = torch.div(output, norm_mask)
+
+        # Crop added margins
+        if self.overlap > 0:
+            unpad_slices = [
+                slice(int(l * self.scale), -int(r * self.scale)) for l, r in zip(pad_l.tolist(), pad_r.tolist())
+            ]
+            output = output[[channel_slice, *unpad_slices]]
+        return output
+
+    def iter_split(self, image: torch.Tensor):
+        """
+        Split image into partially overlapping patches.
+        Pads the image twice:
+            - first to have a size multiple of the patch size
+            - then to have equal padding at the borders.
+        """
+
+        tile_size = self.tile_size
+        tile_step = self.tile_step
+
+        ranges = [range(0, s - sz + 1, st) for (s, sz, st) in zip(image.shape[1:], tile_size, tile_step)]
+        # coordinates of top left pixel of the tile
+        starts = list(itertools.product(*ranges))
+        slices = [[slice(i, i + sz) for i, sz in zip(start, tile_size)] for start in starts]
+        out_slices = [
+            [slice(int(i * self.scale), int((i + sz) * self.scale)) for i, sz in zip(start, tile_size)]
+            for start in starts
+        ]
+        channel_slice = slice(0, image.size(0))
+        # Loop over all slices
+        for in_slice, out_slice in zip(slices, out_slices):
+            tile = image[[channel_slice, *in_slice]]
+            yield tile, out_slice

--- a/pytorch_tools/utils/tiles.py
+++ b/pytorch_tools/utils/tiles.py
@@ -46,7 +46,7 @@ def compute_pyramid_patch_weight_loss(width: int, height: int, depth: Optional[i
     De_y = torch.linspace(0.5, height - 0.5, height).abs()
     De_y = torch.minimum(De_y, De_y.flip(dims=(0,)))
 
-    De_z = torch.tensor(torch.inf)
+    De_z = torch.tensor(float('inf'))
     if depth is not None:
         De_z = torch.linspace(0.5, depth - 0.5, depth).abs()
         De_z = torch.minimum(De_z, De_z.flip(dims=(0,)))

--- a/tests/utils/test_tiles.py
+++ b/tests/utils/test_tiles.py
@@ -1,0 +1,85 @@
+import torch
+import torch.nn.functional as F
+import pytest
+import pytorch_tools as pt
+from pytorch_tools.utils.tiles import compute_pyramid_patch_weight_loss, TileInference
+
+
+def test_pyramid_patch_weight():
+    H, W, D = 10, 20, 30
+    weight_2d = compute_pyramid_patch_weight_loss(H, W)
+    assert weight_2d.shape == torch.Size([1, H, W])
+    # check that it's normalized
+    assert torch.allclose(weight_2d.sum().round().long(), torch.tensor(weight_2d.shape).prod())
+
+    weight_3d = compute_pyramid_patch_weight_loss(H, W, D)
+    assert weight_3d.shape == torch.Size([1, H, W, D])
+    assert torch.allclose(weight_3d.sum().round().long(), torch.tensor(weight_3d.shape).prod())
+
+    SZ = 9
+    w_2d = compute_pyramid_patch_weight_loss(SZ, SZ)
+    w_3d = compute_pyramid_patch_weight_loss(SZ, SZ, SZ)
+    # middle of the weight cube should be proportional to 2d case
+    assert torch.allclose((w_2d / w_3d[..., SZ // 2]), torch.tensor(0.7053), atol=1e-4)
+
+    w_2d = compute_pyramid_patch_weight_loss(5, 5)
+    # fmt: off
+    expected_w_2d = torch.tensor(
+        [[[0.4513, 0.5490, 0.6008, 0.5490, 0.4513],
+          [0.5490, 1.5463, 1.8025, 1.5463, 0.5490],
+          [0.6008, 1.8025, 3.0042, 1.8025, 0.6008],
+          [0.5490, 1.5463, 1.8025, 1.5463, 0.5490],
+          [0.4513, 0.5490, 0.6008, 0.5490, 0.4513]]]
+    )
+    # fmt: on
+    assert torch.allclose(expected_w_2d, w_2d, atol=1e-4)
+
+
+@pytest.mark.parametrize("fusion", ["mean", "pyramid"])
+@pytest.mark.parametrize("overlap", [0, 4, 6])
+@pytest.mark.parametrize(
+    "func_scale",
+    [
+        (lambda x: x.pow(2), 1),
+        (lambda x: F.interpolate(x[None], scale_factor=2)[0], 2),
+        (lambda x: F.avg_pool2d(x[None], 2)[0], 0.5),
+    ],
+)
+def test_tile_inference_2d(func_scale, overlap, fusion):
+    func, scale = func_scale
+    C, H, W = 3, 32, 32
+    large_img = torch.rand(C, H, W)
+    tiler = TileInference(tile_size=(16, 16), overlap=overlap, model=func, scale=scale, fusion=fusion)
+    tiler_res = tiler(large_img)
+    full_res = func(large_img)
+    assert torch.allclose(full_res, tiler_res)
+
+
+def test_tile_inference_2d_large_overlap():
+    with pytest.raises(ValueError):
+        TileInference(tile_size=(16, 16), overlap=8, model=lambda x: x.pow(2))
+
+
+def test_tile_inference_2d_int_size():
+    with pytest.raises(ValueError):
+        TileInference(tile_size=16, overlap=2, model=lambda x: x.pow(2))
+
+
+@pytest.mark.parametrize("fusion", ["mean", "pyramid"])
+@pytest.mark.parametrize("overlap", [0, 2])
+@pytest.mark.parametrize(
+    "func_scale",
+    [
+        (lambda x: x.pow(2), 1),
+        (lambda x: F.interpolate(x[None], scale_factor=2)[0], 2),
+        (lambda x: F.avg_pool3d(x[None], 2)[0], 0.5),
+    ],
+)
+def test_tile_inference_3d(func_scale, overlap, fusion):
+    func, scale = func_scale
+    C, H, W, D = 3, 32, 32, 16
+    large_img = torch.rand(C, H, W, D)
+    tiler = TileInference(tile_size=(16, 16, 8), overlap=overlap, model=func, scale=scale, fusion=fusion)
+    tiler_res = tiler(large_img)
+    full_res = func(large_img)
+    assert torch.allclose(full_res, tiler_res)


### PR DESCRIPTION
@zakajd 
чекни как время будет
* переписал Tiler
* покрыл тестами
* сделал так чтобы работало и для 3d случая (причём как по мне без лишнего кода)
* Реализовал ту идею про которую писал в телеге - теперь есть только два параметра: `tile_size` и `overlap`, падятся только картинки на границе, в центре просто захватываются соседние кусочки. 
* Добавил поддержку scale < 1. Может быть полезно например при сегментациях
* upd. добавил поддержку разного border_pad. идея такая что может быть на границе мы хотим паддинг поменьше/побольше чем overlap в центре